### PR TITLE
fix getUserPermissionsErrors hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ It will also block the viewing of the readonly form.
 
 1.1.3 MediaWiki 1.39x compatible
 
+1.1.4 Fix Permission error page (getUserPermissionsErrors hook)
+
 ### Compatibility
 
 * PHP 8+

--- a/SourceProtection.class.php
+++ b/SourceProtection.class.php
@@ -85,13 +85,14 @@ class SourceProtection {
 			);
 			// Also disable the version difference options
 			if ( isset( $_GET['diff'] ) ) {
-				return [ "no access" ];
+				$result = wfMessage( 'sourceprotection-no-access');
+				return false;
 			}
 			if ( isset( $_GET['action'] ) ) {
-				$actie = $_GET['action'];
-				if ( in_array( $actie,
-					$actionNotAllowed ) ) {
-					return [ "no access" ];
+				$getAction = $_GET['action'];
+				if ( in_array( $getAction, $actionNotAllowed ) ) {
+					$result = wfMessage( 'sourceprotection-no-access');
+					return false;
 				}
 			}
 

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SourceProtection",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"author": [
 		"[https://www.wikibase-solutions.com/author/charlot Sen-Sai]"
 	],

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,5 +4,6 @@
                         "Sen-Sai"
                 ]
         },
-        "sourceprotection-desc": "Removes View Source tab and (if Pageforms is installed the edit-Form tab) & History tab from menu and disable as many action functions for users with no edit permissions. It will also block the viewing of the readonly form."
+        "sourceprotection-desc": "Removes View Source tab and (if Pageforms is installed the edit-Form tab) & History tab from menu and disable as many action functions for users with no edit permissions. It will also block the viewing of the readonly form.",
+        "sourceprotection-no-access": "You are not allowed to do this action. <span class=\"plainlinks\">[{{fullurl:Special:ListUsers|group=sysop}} Contact an administrator]</span> when you think this is an error."
 }


### PR DESCRIPTION
Returning an array does not prevent the action to happen (since the array is truthy). Assigning an error message to `$result` and returning `false` is the correct way to prevent access.