### PR TITLE
Port SourceProtection to MediaWiki 1.43

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ It will also block the viewing of the readonly form.
 
 1.1.3 Version bumb for MW 1.39 branch
 
+1.2.0 Ports the extension to MediaWiki 1.43 by replacing removed/deprecated hooks and modernizing action checks.
+
 ### Compatibility
 
-* PHP 5.4+
-* MediaWiki 1.24+
+* PHP 8.1+ recommended
+* MediaWiki 1.43+
 
 
 ### Installation
@@ -43,3 +45,6 @@ There is no need for additional configuration, besides giving users an edit perm
 It makes no sense to install this extension to hide the sourcecode of a page if you do not take various other actions as well.
 e.g. If you open the API with default edit rights, source content can still be read. Likewise for anonymous users. If they
 receive edit rights, the sourcecode of page can be viewed, edited, etc..
+
+For MediaWiki 1.43, the extension is intended as UI and action hardening. It does not provide full content confidentiality
+against every possible read path or API surface.

--- a/SourceProtection.class.php
+++ b/SourceProtection.class.php
@@ -7,109 +7,122 @@
  *
  */
 
+use MediaWiki\Actions\ActionEntryPoint;
+use MediaWiki\EditPage\EditPage;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Request\WebRequest;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
+
 
 class SourceProtection {
+	/** @var string[] */
+	private const BLOCKED_ACTIONS = [
+		'delete',
+		'edit',
+		'history',
+		'info',
+		'markpatrolled',
+		'move',
+		'raw',
+		'revert',
+		'revisiondelete',
+		'rollback',
+	];
 
 	/**
 	 * Dive into the skin. Check if a user may edit. If not, remove tabs.
 	 * @param SkinTemplate $sktemplate
-	 * @param array $links
-	 *
-	 * @return bool
+	 * @param array &$links
 	 */
-	public static function hideSource( SkinTemplate &$sktemplate, array &$links ) {
-		// always remove viewsource tab
-		$removeUs = array( 'viewsource' );
-		foreach ( $removeUs as $view ) {
-			if ( isset( $links['views'][ $view ] ) ) {
-				unset( $links['views'][ $view ] );
-			}
-		}
-		// grab user permissions
-		if ( method_exists( $sktemplate, 'getTitle' ) ) {
-			$title = $sktemplate->getTitle();
-		} else {
-			$title = $sktemplate->mTitle;
+	public static function hideSource( SkinTemplate $sktemplate, array &$links ): void {
+		unset( $links['views']['viewsource'] );
+
+		$title = $sktemplate->getTitle();
+		if ( !$title ) {
+			return;
 		}
 
-		$user_can_edit = $title->userCan( 'edit' );
-
-		//remove form_edit and history when edit is disabled
-		if ( $user_can_edit === false ) {
-			$rem = array( 'form_edit', 'history' );
-			foreach ( $rem as $v ) {
-				if ( isset( $links['views'][ $v ] ) ) {
-					unset( $links['views'][ $v ] );
-				}
-			}
+		if ( self::userMayEdit( $title, $sktemplate->getUser() ) ) {
+			return;
 		}
 
-		return true;
-
+		unset( $links['views']['form_edit'] );
+		unset( $links['views']['history'] );
 	}
 
 	/**
 	 * If a user has no edit rights, then make sure it is hard for them to view the source of a document
-	 * @param $title
-	 * @param $wgUser
-	 * @param $action
-	 * @param $result
-	 *
-	 * @return bool
+	 * @param Title $title
+	 * @param User $user
+	 * @param string $action
+	 * @param array|string &$result
 	 */
-	public static function disableActions( &$title, &$wgUser, $action, &$result ) {
-		if ( in_array( 'edit', $wgUser->getRights(), true ) ) {
-			return true;
-		} else {
-			// define the actions to be blocked
-			$actionNotAllowed = array(
-				'edit',
-				'move',
-				'history',
-				'info',
-				'raw',
-				'delete',
-				'revert',
-				'revisiondelete',
-				'rollback',
-				'markpatrolled'
-			);
-			// Also disable the version difference options
-			if ( isset( $_GET['diff'] ) ) {
-				return false;
-			}
-			if ( isset( $_GET['action'] ) ) {
-				$actie = $_GET['action'];
-				if ( in_array( $actie, $actionNotAllowed ) ) {
-					return false;
-				}
-			}
-
-			// Any other action is fine
+	public static function disableActions( $title, $user, $action, &$result ) {
+		if ( !self::isBlockedAction( $action ) || self::userMayEdit( $title, $user ) ) {
 			return true;
 		}
+
+		$result = [ 'badaccess-group0' ];
+		return false;
+	}
+
+	/**
+	 * Intercept direct action and diff requests before MediaWiki renders them.
+	 *
+	 * @param OutputPage $output
+	 * @param Article $article
+	 * @param Title $title
+	 * @param User $user
+	 * @param WebRequest $request
+	 * @param ActionEntryPoint $mediaWiki
+	 * @return bool
+	 */
+	public static function preventActionAccess(
+		OutputPage $output,
+		$article,
+		Title $title,
+		User $user,
+		WebRequest $request,
+		ActionEntryPoint $mediaWiki
+	): bool {
+		if ( self::userMayEdit( $title, $user ) ) {
+			return true;
+		}
+
+		if ( !self::shouldBlockRequest( $request, $mediaWiki->getAction() ) ) {
+			return true;
+		}
+
+		$output->redirect( $title->getLocalURL() );
+		return false;
 	}
 
 	/**
 	 * Prevent ShowReadOnly form to be shown. We should never get here anymore, but just in case.
 	 * @param EditPage $editPage
 	 * @param OutputPage $output
-	 *
-	 * @return OutputPage
 	 */
-	public static function doNotShowReadOnlyForm( EditPage $editPage, OutputPage $output ) {
-
-		if ( method_exists( $editPage, 'getTitle' ) ) {
-			$title = $editPage->getTitle();
-		} else {
-			$title = $editPage->mTitle;
-		}
-		$user_can_edit = $title->userCan( 'edit' );
-		if ( ! $user_can_edit ) {
+	public static function doNotShowReadOnlyForm( EditPage $editPage, OutputPage $output ): void {
+		$title = $editPage->getTitle();
+		if ( !self::userMayEdit( $title, $output->getUser() ) ) {
 			$output->redirect( $editPage->getContextTitle() );
 		}
+	}
 
-		return $output;
+	public static function isBlockedAction( string $action ): bool {
+		return in_array( $action, self::BLOCKED_ACTIONS, true );
+	}
+
+	public static function shouldBlockRequest( WebRequest $request, string $action ): bool {
+		return $request->getVal( 'diff' ) !== null || self::isBlockedAction( $action );
+	}
+
+	private static function userMayEdit( Title $title, User $user ): bool {
+		return MediaWikiServices::getInstance()
+			->getPermissionManager()
+			->userHasRight( $user, 'edit' );
 	}
 
 }

--- a/extension.json
+++ b/extension.json
@@ -1,12 +1,16 @@
 {
 	"name": "SourceProtection",
-	"version": "1.1.3",
+	"version": "1.2.0",
 	"author": [
-		"Sen-Sai"
+		"Sen-Sai",
+		"MrBlackRocket"
 	],
 	"license-name": "GPL-2.0+",
-	"url": "https://github.com/Sen-Sai/SourceProtection",
+	"url": "https://github.com/MrBlackRocket/SourceProtection",
 	"descriptionmsg": "sourceprotection-desc",
+	"requires": {
+		"MediaWiki": ">= 1.43.0"
+	},
 	"MessagesDirs": {
 		"SourceProtection": [
 			"i18n"
@@ -19,12 +23,15 @@
 		"EditPage::showReadOnlyForm:initial": [
 			"SourceProtection::doNotShowReadOnlyForm"
 		],
-		"userCan": [
+		"getUserPermissionsErrors": [
 			"SourceProtection::disableActions"
 		],
-		"SkinTemplateNavigation": [
+		"MediaWikiPerformAction": [
+			"SourceProtection::preventActionAccess"
+		],
+		"SkinTemplateNavigation::Universal": [
 			"SourceProtection::hideSource"
 		]
 	},
-	"manifest_version": 1
+	"manifest_version": 2
 }


### PR DESCRIPTION
## Summary

This updates SourceProtection for MediaWiki 1.43 compatibility.

The extension previously relied on hooks and permission handling patterns that are no longer suitable for MW 1.43, which caused breakage after upgrading. This change ports the extension while keeping the existing behavior intact as closely as possible.

## Changes

- replace removed `SkinTemplateNavigation` hook with `SkinTemplateNavigation::Universal`
- replace deprecated `userCan` hook usage with `getUserPermissionsErrors`
- add `MediaWikiPerformAction` handling to continue blocking direct action and diff access
- remove legacy access patterns based on `$wgUser` and `$_GET`
- update extension metadata for MediaWiki 1.43
- update README compatibility notes

## Behavior

For users without the `edit` right, the extension continues to:
- hide the `viewsource` tab
- hide `history` and optional `form_edit` links
- block direct access to actions such as `edit`, `raw`, `history`, and diff requests
- redirect away from the read-only edit form

## Notes

A recursion issue appeared during testing when using a full permission check inside the permission hook. This was fixed by switching to a non-recursive user right check.

This extension should still be understood as UI/action hardening, not as complete content confidentiality across every possible read path.

## Validation

Locally checked with PHP 8.3:
- `php -l SourceProtection.php`
- `php -l SourceProtection.class.php`
- `extension.json` checked against the MediaWiki 1.43 v2 extension schema

Manual wiki-instance testing was performed separately on a MediaWiki 1.43 environment.
